### PR TITLE
Support updating metadata in publish and returning publish details

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,10 +16,10 @@
     "default": {
         "astroid": {
             "hashes": [
-                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
-                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
+                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
+                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
             ],
-            "version": "==1.6.5"
+            "version": "==2.1.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -35,34 +35,19 @@
             ],
             "version": "==18.2.0"
         },
-        "backports.functools-lru-cache": {
-            "hashes": [
-                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
-                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.5"
-        },
         "boto3": {
             "hashes": [
-                "sha256:6d2720ec4b96ead53c6a1401741142209db474b02fda7aac1ad30afd52f17ff1",
-                "sha256:fd566fb6af82667c85783e0c3d1593f0918c52490a1f8e33a2225efb26a50274"
+                "sha256:4f52d5345a2dcaae62f03d194416ec7461faf367b4d885e6319c62fcef5f6a42",
+                "sha256:6e9f48f3cd16f4b4e1e2d9c49c0644568294f67cda1a93f84315526cbd7e70ae"
             ],
-            "version": "==1.9.52"
+            "version": "==1.9.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:45dae714e403299608949879f2e39917b7f99ba3b3588853eb31d40fffd48166",
-                "sha256:86c0712e0a5f496d6a252276a98be022af7f718127f30cc503e45e27c2179eb1"
+                "sha256:ad523b7e530b8fd51b8207ad1c981852399ec8f21b2c32311139daa8b2cbb55e",
+                "sha256:e298eaa3883d5aa62a21e84b68a3b4d47b582fffdb93efefe53144d2ed9a824c"
             ],
-            "version": "==1.12.52"
-        },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
+            "version": "==1.12.60"
         },
         "coverage": {
             "hashes": [
@@ -108,16 +93,6 @@
             ],
             "version": "==0.14"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "flake8": {
             "hashes": [
                 "sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670",
@@ -138,22 +113,6 @@
                 "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
             ],
             "version": "==1.0.2"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.0'",
-            "version": "==1.0.2"
-        },
-        "futures": {
-            "hashes": [
-                "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
-                "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
-            ],
-            "markers": "python_version == '2.6' or python_version == '2.7'",
-            "version": "==3.2.0"
         },
         "isort": {
             "hashes": [
@@ -226,14 +185,6 @@
             ],
             "version": "==4.3.0"
         },
-        "pathlib2": {
-            "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
-            ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.2"
-        },
         "pbr": {
             "hashes": [
                 "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
@@ -279,10 +230,10 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:09bc539f85706f2cca720a7ddf28f5c6cf8185708d6cb5bbf7a90a32c3b3b0aa",
-                "sha256:b8471105f12c73a1b9eee2bb2474080370e062a7290addd215eb34bc4dfe9fd8"
+                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
+                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
             ],
-            "version": "==1.9.3"
+            "version": "==2.2.2"
         },
         "pytest": {
             "hashes": [
@@ -329,37 +280,12 @@
             ],
             "version": "==0.1.13"
         },
-        "scandir": {
-            "hashes": [
-                "sha256:04b8adb105f2ed313a7c2ef0f1cf7aff4871aa7a1883fa4d8c44b5551ab052d6",
-                "sha256:1444134990356c81d12f30e4b311379acfbbcd03e0bab591de2696a3b126d58e",
-                "sha256:1b5c314e39f596875e5a95dd81af03730b338c277c54a454226978d5ba95dbb6",
-                "sha256:346619f72eb0ddc4cf355ceffd225fa52506c92a2ff05318cfabd02a144e7c4e",
-                "sha256:44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064",
-                "sha256:61859fd7e40b8c71e609c202db5b0c1dbec0d5c7f1449dec2245575bdc866792",
-                "sha256:a5e232a0bf188362fa00123cc0bb842d363a292de7126126df5527b6a369586a",
-                "sha256:c14701409f311e7a9b7ec8e337f0815baf7ac95776cc78b419a1e6d49889a383",
-                "sha256:c7708f29d843fc2764310732e41f0ce27feadde453261859ec0fca7865dfc41b",
-                "sha256:c9009c527929f6e25604aec39b0a43c3f831d2947d89d6caaab22f057b7055c8",
-                "sha256:f5c71e29b4e2af7ccdc03a020c626ede51da471173b4a6ad1e904f2b2e04b4bd"
-            ],
-            "markers": "python_version < '3.5'",
-            "version": "==1.9.0"
-        },
         "serverlessrepo": {
             "editable": true,
             "extras": [
                 "dev"
             ],
             "path": "."
-        },
-        "singledispatch": {
-            "hashes": [
-                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
-                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==3.4.0.3"
         },
         "six": {
             "hashes": [
@@ -380,7 +306,7 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "markers": "python_version == '2.7'",
+            "markers": "python_version >= '3.4'",
             "version": "==1.24.1"
         },
         "wrapt": {
@@ -393,10 +319,10 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
-                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
+                "sha256:35b032003d6a863f5dcd7ec11abd5cd5893428beaa31ab164982403bcb311f22",
+                "sha256:6a5d668d7dc69110de01cdf7aeec69a679ef486862a0850cc0fd5571505b6b7e"
             ],
-            "version": "==1.6.5"
+            "version": "==2.1.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -411,21 +337,6 @@
                 "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "version": "==18.2.0"
-        },
-        "backports.functools-lru-cache": {
-            "hashes": [
-                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
-                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.5"
-        },
-        "configparser": {
-            "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
-            ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
         },
         "coverage": {
             "hashes": [
@@ -463,16 +374,6 @@
             ],
             "version": "==4.5.2"
         },
-        "enum34": {
-            "hashes": [
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
-                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==1.1.6"
-        },
         "filelock": {
             "hashes": [
                 "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633",
@@ -500,22 +401,6 @@
                 "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"
             ],
             "version": "==1.0.2"
-        },
-        "funcsigs": {
-            "hashes": [
-                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
-                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
-            ],
-            "markers": "python_version < '3.0'",
-            "version": "==1.0.2"
-        },
-        "futures": {
-            "hashes": [
-                "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
-                "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
-            ],
-            "markers": "python_version == '2.6' or python_version == '2.7'",
-            "version": "==3.2.0"
         },
         "isort": {
             "hashes": [
@@ -581,14 +466,6 @@
             ],
             "version": "==4.3.0"
         },
-        "pathlib2": {
-            "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
-            ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.2"
-        },
         "pbr": {
             "hashes": [
                 "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
@@ -634,10 +511,10 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:09bc539f85706f2cca720a7ddf28f5c6cf8185708d6cb5bbf7a90a32c3b3b0aa",
-                "sha256:b8471105f12c73a1b9eee2bb2474080370e062a7290addd215eb34bc4dfe9fd8"
+                "sha256:689de29ae747642ab230c6d37be2b969bf75663176658851f456619aacf27492",
+                "sha256:771467c434d0d9f081741fec1d64dfb011ed26e65e12a28fe06ca2f61c4d556c"
             ],
-            "version": "==1.9.3"
+            "version": "==2.2.2"
         },
         "pytest": {
             "hashes": [
@@ -652,31 +529,6 @@
                 "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
             ],
             "version": "==2.6.0"
-        },
-        "scandir": {
-            "hashes": [
-                "sha256:04b8adb105f2ed313a7c2ef0f1cf7aff4871aa7a1883fa4d8c44b5551ab052d6",
-                "sha256:1444134990356c81d12f30e4b311379acfbbcd03e0bab591de2696a3b126d58e",
-                "sha256:1b5c314e39f596875e5a95dd81af03730b338c277c54a454226978d5ba95dbb6",
-                "sha256:346619f72eb0ddc4cf355ceffd225fa52506c92a2ff05318cfabd02a144e7c4e",
-                "sha256:44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064",
-                "sha256:61859fd7e40b8c71e609c202db5b0c1dbec0d5c7f1449dec2245575bdc866792",
-                "sha256:a5e232a0bf188362fa00123cc0bb842d363a292de7126126df5527b6a369586a",
-                "sha256:c14701409f311e7a9b7ec8e337f0815baf7ac95776cc78b419a1e6d49889a383",
-                "sha256:c7708f29d843fc2764310732e41f0ce27feadde453261859ec0fca7865dfc41b",
-                "sha256:c9009c527929f6e25604aec39b0a43c3f831d2947d89d6caaab22f057b7055c8",
-                "sha256:f5c71e29b4e2af7ccdc03a020c626ede51da471173b4a6ad1e904f2b2e04b4bd"
-            ],
-            "markers": "python_version < '3.5'",
-            "version": "==1.9.0"
-        },
-        "singledispatch": {
-            "hashes": [
-                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
-                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
-            ],
-            "markers": "python_version < '3.4'",
-            "version": "==3.4.0.3"
         },
         "six": {
             "hashes": [

--- a/serverlessrepo/application_metadata.py
+++ b/serverlessrepo/application_metadata.py
@@ -7,16 +7,16 @@ class ApplicationMetadata(object):
     """Class representing SAR metadata."""
 
     # SAM template SAR metadata properties
-    _NAME = 'Name'
-    _DESCRIPTION = 'Description'
-    _AUTHOR = 'Author'
-    _SPDX_LICENSE_ID = 'SpdxLicenseId'
-    _LICENSE_URL = 'LicenseUrl'
-    _README_URL = 'ReadmeUrl'
-    _LABELS = 'Labels'
-    _HOMEPAGE_URL = 'HomepageUrl'
-    _SEMANTIC_VERSION = 'SemanticVersion'
-    _SOURCE_CODE_URL = 'SourceCodeUrl'
+    NAME = 'Name'
+    DESCRIPTION = 'Description'
+    AUTHOR = 'Author'
+    SPDX_LICENSE_ID = 'SpdxLicenseId'
+    LICENSE_URL = 'LicenseUrl'
+    README_URL = 'ReadmeUrl'
+    LABELS = 'Labels'
+    HOME_PAGE_URL = 'HomePageUrl'
+    SEMANTIC_VERSION = 'SemanticVersion'
+    SOURCE_CODE_URL = 'SourceCodeUrl'
 
     def __init__(self, app_metadata):
         """
@@ -25,16 +25,17 @@ class ApplicationMetadata(object):
         :param app_metadata: Dictionary containing SAR metadata properties
         :type app_metadata: dict
         """
-        self.name = app_metadata.get(self._NAME)
-        self.description = app_metadata.get(self._DESCRIPTION)
-        self.author = app_metadata.get(self._AUTHOR)
-        self.spdx_license_id = app_metadata.get(self._SPDX_LICENSE_ID)
-        self.license_url = app_metadata.get(self._LICENSE_URL)
-        self.readme_url = app_metadata.get(self._README_URL)
-        self.labels = app_metadata.get(self._LABELS)
-        self.home_page_url = app_metadata.get(self._HOMEPAGE_URL)
-        self.semantic_version = app_metadata.get(self._SEMANTIC_VERSION)
-        self.source_code_url = app_metadata.get(self._SOURCE_CODE_URL)
+        self.template_dict = app_metadata  # save the original template definitions
+        self.name = app_metadata.get(self.NAME)
+        self.description = app_metadata.get(self.DESCRIPTION)
+        self.author = app_metadata.get(self.AUTHOR)
+        self.spdx_license_id = app_metadata.get(self.SPDX_LICENSE_ID)
+        self.license_url = app_metadata.get(self.LICENSE_URL)
+        self.readme_url = app_metadata.get(self.README_URL)
+        self.labels = app_metadata.get(self.LABELS)
+        self.home_page_url = app_metadata.get(self.HOME_PAGE_URL)
+        self.semantic_version = app_metadata.get(self.SEMANTIC_VERSION)
+        self.source_code_url = app_metadata.get(self.SOURCE_CODE_URL)
 
     def __eq__(self, other):
         """Return whether two ApplicationMetadata objects are equal."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,8 @@ max-line-length = 120
 
 [bdist_wheel]
 universal=1
+
+[coverage:run]
+omit =
+    # omit package metadata file
+    serverlessrepo/__version__.py

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ from setuptools import setup, find_packages
 
 # Required packages for this module to work
 REQUIRED = [
-    'pyyaml',
-    'boto3',
-    'six'
+    'pyyaml~=3.12',
+    'boto3~=1.9, >=1.9.56',
+    'six~=1.11.0'
 ]
 
 # Optional packages for this module to work

--- a/tests/unit/test_application_metadata.py
+++ b/tests/unit/test_application_metadata.py
@@ -15,7 +15,7 @@ class TestApplicationMetadata(TestCase):
             'LicenseUrl': 's3://bucket/license.txt',
             'ReadmeUrl': 's3://bucket/README.md',
             'Labels': ['label1', 'label2', 'label3'],
-            'HomepageUrl': 'https://github.com/my-id/my-repo/',
+            'HomePageUrl': 'https://github.com/my-id/my-repo/',
             'SemanticVersion': '1.0.0',
             'SourceCodeUrl': 's3://bucket/code.zip'
         }
@@ -27,7 +27,7 @@ class TestApplicationMetadata(TestCase):
         self.assertEqual(app_metadata.license_url, app_metadata_dict['LicenseUrl'])
         self.assertEqual(app_metadata.readme_url, app_metadata_dict['ReadmeUrl'])
         self.assertEqual(app_metadata.labels, app_metadata_dict['Labels'])
-        self.assertEqual(app_metadata.home_page_url, app_metadata_dict['HomepageUrl'])
+        self.assertEqual(app_metadata.home_page_url, app_metadata_dict['HomePageUrl'])
         self.assertEqual(app_metadata.semantic_version, app_metadata_dict['SemanticVersion'])
         self.assertEqual(app_metadata.source_code_url, app_metadata_dict['SourceCodeUrl'])
 


### PR DESCRIPTION
*Description of changes:*

* Show actions taken during publishing: create application/update metadata/create version

* Show changes of application details after publishing

* Fix HomePageUrl name inconsistency between metadata spec and boto3 API

* Ignore `__version__.py` when calculating code coverage

* Pin dependency versions as SAM CLI

Please ignore changes in `Pipfile.lock`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
