### PR TITLE
Move boto3 client into functions, add publish output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,22 @@ import serverlessrepo
 
 ### Publish Applications
 
-#### publish_application(template)
+#### publish_application(template, sar_client)
 
 Given an [AWS Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md) template, it publishes a new application using the specified metadata in AWS Serverless Application Repository. If the application already exists, it updates metadata of the application and publishes a new version if specified in the template.
 
 For example:
 
 ```python
+import boto3
 from serverlessrepo import publish_application
+
+sar_client = boto3.client('serverlessrepo', region_name='us-east-1')
 
 with open('template.yaml', 'r') as f:
     template = f.read()
-    output = publish_application(template)
+    # if sar_client is not provided, we will initiate the client using region inferred from aws configurations
+    output = publish_application(template, sar_client)
     print (output)
 ```
 
@@ -63,38 +67,43 @@ There are three possible values for the `actions` field:
 * If application is updated, it shows updated metadata values.
 * If application is updated and new version is created, it shows updated metadata values as well as the new version number.
 
-#### update_application_metadata(template, application_id)
+#### update_application_metadata(template, application_id, sar_client)
 
 Parses the application metadata from the SAM template and only updates the metadata.
 
 For example:
 
 ```python
+import boto3
 from serverlessrepo import update_application_metadata
+
+sar_client = boto3.client('serverlessrepo', region_name='us-east-1')
 
 with open('template.yaml', 'r') as f:
     template = f.read()
     application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
-    update_application_metadata(template, application_id)
+    # if sar_client is not provided, we will initiate the client using region inferred from aws configurations
+    update_application_metadata(template, application_id, sar_client)
 ```
 
 ### Manage Application Permissions
 
-#### make_application_public(application_id)
+#### make_application_public(application_id, sar_client)
 
 Makes an application public so that it's visible to everyone.
 
-#### make_application_private(application_id)
+#### make_application_private(application_id, sar_client)
 
 Makes an application private so that it's only visible to the owner.
 
-#### share_application_with_accounts(application_id, account_ids)
+#### share_application_with_accounts(application_id, account_ids, sar_client)
 
 Shares the application with specified AWS accounts.
 
 #### Examples
 
 ```python
+import boto3
 from serverlessrepo import (
     make_application_public,
     make_application_private,
@@ -102,15 +111,16 @@ from serverlessrepo import (
 )
 
 application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
+sar_client = boto3.client('serverlessrepo', region_name='us-east-1')
 
 # Share an application publicly
-make_application_public(application_id)
+make_application_public(application_id, sar_client)
 
 # Make an application private
-make_application_private(application_id)
+make_application_private(application_id, sar_client)
 
 # Share an application with other AWS accounts
-share_application_with_accounts(application_id, ['123456789013', '123456789014'])
+share_application_with_accounts(application_id, ['123456789013', '123456789014'], sar_client)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -22,25 +22,52 @@ import serverlessrepo
 
 #### publish_application(template)
 
-Given an [AWS Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md) template, it publishes a new application using the specified metadata in AWS Serverless Application Repository. If the application already exists, it publishes a new application version.
+Given an [AWS Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md) template, it publishes a new application using the specified metadata in AWS Serverless Application Repository. If the application already exists, it updates metadata of the application and publishes a new version if specified in the template.
 
-#### update_application_metadata(template, application_id)
-
-Parses the application metadata from the SAM template and updates the application.
-
-#### Examples
-
-Publish an application using local file template.yaml:
+For example:
 
 ```python
 from serverlessrepo import publish_application
 
 with open('template.yaml', 'r') as f:
     template = f.read()
-    publish_application(template)
+    output = publish_application(template)
+    print (output)
 ```
 
-Or updates the application's metadata using template.yaml:
+The output of `publish_application` has the following structure:
+
+```text
+{
+    'application_id': 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app',
+    'actions': ['CREATE_APPLICATION'],
+    'details': {
+        'Author': 'user1',
+        'Description': 'hello',
+        'Name': 'hello-world',
+        'SemanticVersion': '0.0.1',
+        'SourceCodeUrl': 'https://github.com/hello'}
+    }
+}
+```
+
+There are three possible values for the `actions` field:
+
+* `['CREATE_APPLICATION']` - Created a new application.
+* `['UPDATE_APPLICATION']` - Updated metadata of an existing application.
+* `['UPDATE_APPLICATION', 'CREATE_APPLICATION_VERSION']` - Updated metadata of an existing application and created a new version, only applicable if a new SemanticVersion is provided in the input template.
+
+`details` has different meaning based on the `actions` taken:
+
+* If a new application is created, it shows metadata values used to create the application.
+* If application is updated, it shows updated metadata values.
+* If application is updated and new version is created, it shows updated metadata values as well as the new version number.
+
+#### update_application_metadata(template, application_id)
+
+Parses the application metadata from the SAM template and only updates the metadata.
+
+For example:
 
 ```python
 from serverlessrepo import update_application_metadata
@@ -88,8 +115,8 @@ share_application_with_accounts(application_id, ['123456789013', '123456789014']
 
 ## Development
 
-* Clone the project to your local:
-  * `git clone https://github.com/awslabs/aws-serverlessrepo-python.git`
+* Fork the repository, then clone to your local:
+  * `git clone https://github.com/<username>/aws-serverlessrepo-python.git`
 * Set up the environment: `make init`
   * It installs [Pipenv](https://github.com/pypa/pipenv) to manage package dependencies. Then it creates a virtualenv and installs dependencies from [Pipfile](./Pipfile) (including dev).
 * Install new packages: `pipenv install [package names]`

--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '

--- a/serverlessrepo/permission_helper.py
+++ b/serverlessrepo/permission_helper.py
@@ -5,43 +5,53 @@ import boto3
 from .application_policy import ApplicationPolicy
 
 
-def make_application_public(application_id):
+def make_application_public(application_id, sar_client=None):
     """
     Set the application to be public.
 
     :param application_id: The Amazon Resource Name (ARN) of the application
     :type application_id: str
+    :param sar_client: The boto3 client used to access SAR
+    :type sar_client: boto3.client
     :raises ValueError
     """
     if not application_id:
         raise ValueError('Require application id to make the app public')
 
+    if not sar_client:
+        sar_client = boto3.client('serverlessrepo')
+
     application_policy = ApplicationPolicy(['*'], [ApplicationPolicy.DEPLOY])
     application_policy.validate()
-    boto3.client('serverlessrepo').put_application_policy(
+    sar_client.put_application_policy(
         ApplicationId=application_id,
         Statements=[application_policy.to_statement()]
     )
 
 
-def make_application_private(application_id):
+def make_application_private(application_id, sar_client=None):
     """
     Set the application to be private.
 
     :param application_id: The Amazon Resource Name (ARN) of the application
     :type application_id: str
+    :param sar_client: The boto3 client used to access SAR
+    :type sar_client: boto3.client
     :raises ValueError
     """
     if not application_id:
         raise ValueError('Require application id to make the app private')
 
-    boto3.client('serverlessrepo').put_application_policy(
+    if not sar_client:
+        sar_client = boto3.client('serverlessrepo')
+
+    sar_client.put_application_policy(
         ApplicationId=application_id,
         Statements=[]
     )
 
 
-def share_application_with_accounts(application_id, account_ids):
+def share_application_with_accounts(application_id, account_ids, sar_client=None):
     """
     Share the application privately with given AWS account IDs.
 
@@ -49,14 +59,19 @@ def share_application_with_accounts(application_id, account_ids):
     :type application_id: str
     :param account_ids: List of AWS account IDs, or *
     :type account_ids: list of str
+    :param sar_client: The boto3 client used to access SAR
+    :type sar_client: boto3.client
     :raises ValueError
     """
     if not application_id or not account_ids:
         raise ValueError('Require application id and list of AWS account IDs to share the app')
 
+    if not sar_client:
+        sar_client = boto3.client('serverlessrepo')
+
     application_policy = ApplicationPolicy(account_ids, [ApplicationPolicy.DEPLOY])
     application_policy.validate()
-    boto3.client('serverlessrepo').put_application_policy(
+    sar_client.put_application_policy(
         ApplicationId=application_id,
         Statements=[application_policy.to_statement()]
     )

--- a/serverlessrepo/permission_helper.py
+++ b/serverlessrepo/permission_helper.py
@@ -9,6 +9,8 @@ def make_application_public(application_id):
     """
     Set the application to be public.
 
+    :param application_id: The Amazon Resource Name (ARN) of the application
+    :type application_id: str
     :raises ValueError
     """
     if not application_id:
@@ -26,6 +28,8 @@ def make_application_private(application_id):
     """
     Set the application to be private.
 
+    :param application_id: The Amazon Resource Name (ARN) of the application
+    :type application_id: str
     :raises ValueError
     """
     if not application_id:
@@ -41,6 +45,8 @@ def share_application_with_accounts(application_id, account_ids):
     """
     Share the application privately with given AWS account IDs.
 
+    :param application_id: The Amazon Resource Name (ARN) of the application
+    :type application_id: str
     :param account_ids: List of AWS account IDs, or *
     :type account_ids: list of str
     :raises ValueError

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -11,12 +11,14 @@ UPDATE_APPLICATION = 'UPDATE_APPLICATION'
 CREATE_APPLICATION_VERSION = 'CREATE_APPLICATION_VERSION'
 
 
-def publish_application(template):
+def publish_application(template, sar_client=None):
     """
     Create a new application or new application version in SAR.
 
     :param template: A packaged YAML or JSON SAM template
     :type template: str
+    :param sar_client: The boto3 client used to access SAR
+    :type sar_client: boto3.client
     :return: Dictionary containing application id, actions taken, and updated details
     :rtype: dict
     :raises ValueError
@@ -26,11 +28,12 @@ def publish_application(template):
 
     template_dict = parse_template(template)
     app_metadata = get_app_metadata(template_dict)
-    serverlessrepo = boto3.client('serverlessrepo')
+    if not sar_client:
+        sar_client = boto3.client('serverlessrepo')
 
     try:
         request = _create_application_request(app_metadata, template)
-        response = serverlessrepo.create_application(**request)
+        response = sar_client.create_application(**request)
         application_id = response['ApplicationId']
         actions = [CREATE_APPLICATION]
     except ClientError as e:
@@ -41,14 +44,14 @@ def publish_application(template):
         error_message = e.response['Error']['Message']
         application_id = parse_application_id(error_message)
         request = _update_application_request(app_metadata, application_id)
-        serverlessrepo.update_application(**request)
+        sar_client.update_application(**request)
         actions = [UPDATE_APPLICATION]
 
         # Create application version if semantic version is specified
         if app_metadata.semantic_version:
             try:
                 request = _create_application_version_request(app_metadata, application_id, template)
-                serverlessrepo.create_application_version(**request)
+                sar_client.create_application_version(**request)
                 actions.append(CREATE_APPLICATION_VERSION)
             except ClientError as e:
                 if not _is_conflict_exception(e):
@@ -61,7 +64,7 @@ def publish_application(template):
     }
 
 
-def update_application_metadata(template, application_id):
+def update_application_metadata(template, application_id, sar_client=None):
     """
     Update the application metadata.
 
@@ -69,15 +72,20 @@ def update_application_metadata(template, application_id):
     :type template: str
     :param application_id: The Amazon Resource Name (ARN) of the application
     :type application_id: str
+    :param sar_client: The boto3 client used to access SAR
+    :type sar_client: boto3.client
     :raises ValueError
     """
     if not template or not application_id:
         raise ValueError('Require SAM template and application ID to update application metadata')
 
+    if not sar_client:
+        sar_client = boto3.client('serverlessrepo')
+
     template_dict = parse_template(template)
     app_metadata = get_app_metadata(template_dict)
     request = _update_application_request(app_metadata, application_id)
-    boto3.client('serverlessrepo').update_application(**request)
+    sar_client.update_application(**request)
 
 
 def _create_application_request(app_metadata, template):

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from mock import patch, Mock
 from botocore.exceptions import ClientError
 
 from serverlessrepo import publish_application, update_application_metadata
@@ -15,9 +15,11 @@ from serverlessrepo.publish import (
 class TestPublishApplication(TestCase):
 
     def setUp(self):
-        patcher = patch('serverlessrepo.publish.SERVERLESSREPO')
+        patcher = patch('serverlessrepo.publish.boto3')
         self.addCleanup(patcher.stop)
-        self.serverlessrepo_mock = patcher.start()
+        self.boto3_mock = patcher.start()
+        self.serverlessrepo_mock = Mock()
+        self.boto3_mock.client.return_value = self.serverlessrepo_mock
         self.template = """
         {
             "Metadata": {
@@ -196,9 +198,11 @@ class TestPublishApplication(TestCase):
 
 class TestPublishApplicationMetadata(TestCase):
     def setUp(self):
-        patcher = patch('serverlessrepo.publish.SERVERLESSREPO')
+        patcher = patch('serverlessrepo.publish.boto3')
         self.addCleanup(patcher.stop)
-        self.serverlessrepo_mock = patcher.start()
+        self.boto3_mock = patcher.start()
+        self.serverlessrepo_mock = Mock()
+        self.boto3_mock.client.return_value = self.serverlessrepo_mock
         self.template = """
         {
             "Metadata": {


### PR DESCRIPTION
*Description of changes:*
* I ran into `botocore.exceptions.NoRegionError: You must specify a region` error in SAM CLI when `--region` was provided. I found that it's because the serverlessrepo boto3 client was initialized as a global variable in this library, so region has to be configured before importing. I think the better way is to defer boto3 client initialization until `publish_application` is actually called (AWS region and credentials will have already been set through CLI context at this point).
* Added example output of `publish_application` in README, fixed a few missing params in docstrings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
