### PR TITLE
Add wait time to verify version created when publishing new app

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import serverlessrepo
 
 ### Publish Applications
 
-#### publish_application(template, sar_client)
+#### publish_application(template, sar_client=None)
 
 Given an [AWS Serverless Application Model (SAM)](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md) template, it publishes a new application using the specified metadata in AWS Serverless Application Repository. If the application already exists, it updates metadata of the application and publishes a new version if specified in the template.
 
@@ -67,7 +67,7 @@ There are three possible values for the `actions` field:
 * If application is updated, it shows updated metadata values.
 * If application is updated and new version is created, it shows updated metadata values as well as the new version number.
 
-#### update_application_metadata(template, application_id, sar_client)
+#### update_application_metadata(template, application_id, sar_client=None)
 
 Parses the application metadata from the SAM template and only updates the metadata.
 
@@ -88,15 +88,15 @@ with open('template.yaml', 'r') as f:
 
 ### Manage Application Permissions
 
-#### make_application_public(application_id, sar_client)
+#### make_application_public(application_id, sar_client=None)
 
 Makes an application public so that it's visible to everyone.
 
-#### make_application_private(application_id, sar_client)
+#### make_application_private(application_id, sar_client=None)
 
 Makes an application private so that it's only visible to the owner.
 
-#### share_application_with_accounts(application_id, account_ids, sar_client)
+#### share_application_with_accounts(application_id, account_ids, sar_client=None)
 
 Shares the application with specified AWS accounts.
 

--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '


### PR DESCRIPTION
*Description of changes:*
If I immediately set permission to be public after creating a new app, it will give me a `Only application with published version can use principal *` exception because application version is created asynchronously. This PR is to add a wait time so that when `publish_application` returns the version is guaranteed to exist.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
