### PR TITLE
chore: Wrap S3 access denied exception with a better error message

### DIFF
--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '

--- a/serverlessrepo/exceptions.py
+++ b/serverlessrepo/exceptions.py
@@ -27,3 +27,13 @@ class InvalidApplicationPolicyError(ServerlessRepoError):
     """Raised when invalid application policy is provided."""
 
     MESSAGE = "Invalid application policy: '{error_message}'"
+
+
+class S3PermissionsRequired(ServerlessRepoError):
+    """Raised when S3 bucket access is denied."""
+
+    MESSAGE = "The AWS Serverless Application Repository does not have read access to bucket '{bucket}', " \
+              "key '{key}'. Please update your Amazon S3 bucket policy to grant the service read " \
+              "permissions to the application artifacts you have uploaded to your S3 bucket. See " \
+              "https://docs.aws.amazon.com/serverlessrepo/latest/devguide/serverless-app-publishing-applications.html" \
+              " for more details."

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -1,10 +1,12 @@
 """Module containing functions to publish or update application."""
 
+import re
 import boto3
 from botocore.exceptions import ClientError
 
 from .application_metadata import ApplicationMetadata
 from .parser import parse_template, get_app_metadata, parse_application_id
+from .exceptions import S3PermissionsRequired
 
 CREATE_APPLICATION = 'CREATE_APPLICATION'
 UPDATE_APPLICATION = 'UPDATE_APPLICATION'
@@ -38,14 +40,17 @@ def publish_application(template, sar_client=None):
         actions = [CREATE_APPLICATION]
     except ClientError as e:
         if not _is_conflict_exception(e):
-            raise
+            raise _wrap_s3_exception(e)
 
         # Update the application if it already exists
         error_message = e.response['Error']['Message']
         application_id = parse_application_id(error_message)
-        request = _update_application_request(app_metadata, application_id)
-        sar_client.update_application(**request)
-        actions = [UPDATE_APPLICATION]
+        try:
+            request = _update_application_request(app_metadata, application_id)
+            sar_client.update_application(**request)
+            actions = [UPDATE_APPLICATION]
+        except ClientError as e:
+            raise _wrap_s3_exception(e)
 
         # Create application version if semantic version is specified
         if app_metadata.semantic_version:
@@ -55,7 +60,7 @@ def publish_application(template, sar_client=None):
                 actions.append(CREATE_APPLICATION_VERSION)
             except ClientError as e:
                 if not _is_conflict_exception(e):
-                    raise
+                    raise _wrap_s3_exception(e)
 
     return {
         'application_id': application_id,
@@ -172,6 +177,24 @@ def _is_conflict_exception(e):
     """
     error_code = e.response['Error']['Code']
     return error_code == 'ConflictException'
+
+
+def _wrap_s3_exception(e):
+    """
+    Wrap S3 access denied exception with a better error message.
+
+    :param e: boto3 exception
+    :type e: ClientError
+    :return: S3PermissionsRequired if S3 access denied or the original exception
+    """
+    error_code = e.response['Error']['Code']
+    message = e.response['Error']['Message']
+
+    if error_code == 'BadRequestException' and "Failed to copy S3 object" in message:
+        match = re.search('bucket=(.+?), key=(.+?)$', message)
+        return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
+
+    return e
 
 
 def _get_publish_details(actions, app_metadata_template):

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -192,7 +192,8 @@ def _wrap_s3_exception(e):
 
     if error_code == 'BadRequestException' and "Failed to copy S3 object. Access denied:" in message:
         match = re.search('bucket=(.+?), key=(.+?)$', message)
-        return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
+        if match:
+            return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
 
     return e
 

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -190,7 +190,7 @@ def _wrap_s3_exception(e):
     error_code = e.response['Error']['Code']
     message = e.response['Error']['Message']
 
-    if error_code == 'BadRequestException' and "Failed to copy S3 object" in message:
+    if error_code == 'BadRequestException' and "Failed to copy S3 object. Access denied:" in message:
         match = re.search('bucket=(.+?), key=(.+?)$', message)
         return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
 

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -3,7 +3,7 @@ from mock import patch, Mock
 from botocore.exceptions import ClientError
 
 from serverlessrepo import publish_application, update_application_metadata
-from serverlessrepo.exceptions import InvalidApplicationMetadataError
+from serverlessrepo.exceptions import InvalidApplicationMetadataError, S3PermissionsRequired
 from serverlessrepo.parser import parse_template, get_app_metadata
 from serverlessrepo.publish import (
     CREATE_APPLICATION,
@@ -49,7 +49,19 @@ class TestPublishApplication(TestCase):
         )
         self.not_conflict_exception = ClientError(
             {
-                'Error': {'Code': 'BadRequestException'}
+                'Error': {
+                    'Code': 'BadRequestException',
+                    'Message': 'Random message'
+                }
+            },
+            'create_application'
+        )
+        self.s3_denied_exception = ClientError(
+            {
+                'Error': {
+                    'Code': 'BadRequestException',
+                    'Message': 'Failed to copy S3 object. Access denied: bucket=test-bucket, key=test-file'
+                }
             },
             'create_application'
         )
@@ -93,12 +105,25 @@ class TestPublishApplication(TestCase):
         # create_application shouldn't be called if application metadata is invalid
         self.serverlessrepo_mock.create_application.assert_not_called()
 
-    def test_publish_exception_when_serverlessrepo_create_application(self):
+    def test_publish_raise_client_error_when_create_application(self):
         self.serverlessrepo_mock.create_application.side_effect = self.not_conflict_exception
 
         # should raise exception if it's not ConflictException
         with self.assertRaises(ClientError):
             publish_application(self.template)
+
+        # shouldn't call the following APIs if the exception isn't application already exists
+        self.serverlessrepo_mock.update_application.assert_not_called()
+        self.serverlessrepo_mock.create_application_version.assert_not_called()
+
+    def test_publish_raise_s3_error_when_create_application(self):
+        self.serverlessrepo_mock.create_application.side_effect = self.s3_denied_exception
+        with self.assertRaises(S3PermissionsRequired) as context:
+            publish_application(self.template)
+
+        message = str(context.exception)
+        self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
+                      "'test-bucket', key 'test-file'.", message)
 
         # shouldn't call the following APIs if the exception isn't application already exists
         self.serverlessrepo_mock.update_application.assert_not_called()
@@ -128,6 +153,19 @@ class TestPublishApplication(TestCase):
         expected_request = dict({'ApplicationId': self.application_id}, **expected_result['details'])
         self.serverlessrepo_mock.update_application.assert_called_once_with(**expected_request)
         # create_application_version shouldn't be called if version is not provided
+        self.serverlessrepo_mock.create_application_version.assert_not_called()
+
+    def test_publish_raise_s3_error_when_update_application(self):
+        self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
+        self.serverlessrepo_mock.update_application.side_effect = self.s3_denied_exception
+        with self.assertRaises(S3PermissionsRequired) as context:
+            publish_application(self.template)
+
+        message = str(context.exception)
+        self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
+                      "'test-bucket', key 'test-file'.", message)
+
+        # create_application_version shouldn't be called if update_application fails
         self.serverlessrepo_mock.create_application_version.assert_not_called()
 
     def test_publish_existing_application_should_update_application_if_version_exists(self):
@@ -187,13 +225,23 @@ class TestPublishApplication(TestCase):
         }
         self.serverlessrepo_mock.create_application_version.assert_called_once_with(**expected_request)
 
-    def test_publish_exception_when_serverlessrepo_create_application_version(self):
+    def test_publish_raise_client_error_when_create_application_version(self):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
         self.serverlessrepo_mock.create_application_version.side_effect = self.not_conflict_exception
 
         # should raise exception if it's not ConflictException
         with self.assertRaises(ClientError):
             publish_application(self.template)
+
+    def test_publish_raise_s3_error_when_create_application_version(self):
+        self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
+        self.serverlessrepo_mock.create_application_version.side_effect = self.s3_denied_exception
+        with self.assertRaises(S3PermissionsRequired) as context:
+            publish_application(self.template)
+
+        message = str(context.exception)
+        self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
+                      "'test-bucket', key 'test-file'.", message)
 
     def test_create_application_with_passed_in_sar_client(self):
         sar_client = Mock()


### PR DESCRIPTION
*Description of changes:*
If serverlessrepo doesn't have read permissions to the application artifacts uploaded to S3, boto3 throws `BadRequestException: An error occurred (BadRequestException) when calling the UpdateApplication operation: Failed to copy S3 object. Access denied: bucket=qwang-test-tmp, key=README.md`. This PR wraps such exception with a better error message that clearly states what customers need to do. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
