### PR TITLE
fix: strip app metadata in templates sent to SAR, use OrderedDict for json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For example:
 
 ```python
 import boto3
+import yaml
 from serverlessrepo import publish_application
 
 sar_client = boto3.client('serverlessrepo', region_name='us-east-1')
@@ -36,7 +37,10 @@ with open('template.yaml', 'r') as f:
     template = f.read()
     # if sar_client is not provided, we will initiate the client using region inferred from aws configurations
     output = publish_application(template, sar_client)
-    print (output)
+
+    # Alternatively, pass parsed template as a dictionary
+    template_dict = yaml.loads(template)
+    output = publish_application(template_dict, sar_client)
 ```
 
 The output of `publish_application` has the following structure:
@@ -75,6 +79,7 @@ For example:
 
 ```python
 import boto3
+import yaml
 from serverlessrepo import update_application_metadata
 
 sar_client = boto3.client('serverlessrepo', region_name='us-east-1')
@@ -84,6 +89,10 @@ with open('template.yaml', 'r') as f:
     application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
     # if sar_client is not provided, we will initiate the client using region inferred from aws configurations
     update_application_metadata(template, application_id, sar_client)
+
+    # Alternatively, pass parsed template as a dictionary
+    template_dict = yaml.loads(template)
+    update_application_metadata(template_dict, application_id, sar_client)
 ```
 
 ### Manage Application Permissions

--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '

--- a/serverlessrepo/parser.py
+++ b/serverlessrepo/parser.py
@@ -105,8 +105,8 @@ def get_app_metadata(template_dict):
     :rtype: ApplicationMetadata
     :raises ApplicationMetadataNotFoundError
     """
-    if METADATA in template_dict and SERVERLESS_REPO_APPLICATION in template_dict[METADATA]:
-        app_metadata_dict = template_dict[METADATA][SERVERLESS_REPO_APPLICATION]
+    if SERVERLESS_REPO_APPLICATION in template_dict.get(METADATA, {}):
+        app_metadata_dict = template_dict.get(METADATA).get(SERVERLESS_REPO_APPLICATION)
         return ApplicationMetadata(app_metadata_dict)
 
     raise ApplicationMetadataNotFoundError(
@@ -135,6 +135,9 @@ def strip_app_metadata(template_dict):
     :return: stripped template content
     :rtype: str
     """
+    if SERVERLESS_REPO_APPLICATION not in template_dict.get(METADATA, {}):
+        return template_dict
+
     template_dict_copy = copy.deepcopy(template_dict)
 
     # strip the whole metadata section if SERVERLESS_REPO_APPLICATION is the only key in it
@@ -143,4 +146,4 @@ def strip_app_metadata(template_dict):
     else:
         template_dict_copy.get(METADATA).pop(SERVERLESS_REPO_APPLICATION, None)
 
-    return yaml_dump(template_dict_copy)
+    return template_dict_copy

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -199,6 +199,11 @@ class TestParser(TestCase):
         result = parser.parse_application_id(text_without_application_id)
         self.assertIsNone(result)
 
+    def test_strip_app_metadata_when_input_does_not_contain_metadata(self):
+        template_dict = {'Resources': {}}
+        actual_output = parser.strip_app_metadata(template_dict)
+        self.assertEqual(actual_output, template_dict)
+
     def test_strip_app_metadata_when_metadata_only_contains_app_metadata(self):
         template_dict = {
             'Metadata': {
@@ -206,9 +211,9 @@ class TestParser(TestCase):
             },
             'Resources': {},
         }
-        expected_output = 'Resources:{}'
+        expected_output = {'Resources': {}}
         actual_output = parser.strip_app_metadata(template_dict)
-        self.assertEqual(re.sub(r'\n|\s', '', actual_output), expected_output)
+        self.assertEqual(actual_output, expected_output)
 
     def test_strip_app_metadata_when_metadata_contains_additional_keys(self):
         template_dict = {
@@ -218,11 +223,11 @@ class TestParser(TestCase):
             },
             'Resources': {}
         }
-        expected_output = """
-        Metadata:
-            AnotherKey: {}
-        Resources: {}
-        """
+        expected_output = {
+            'Metadata': {
+                'AnotherKey': {}
+            },
+            'Resources': {}
+        }
         actual_output = parser.strip_app_metadata(template_dict)
-        self.assertEqual(re.sub(r'\n|\s', '', actual_output),
-                         re.sub(r'\n|\s', '', expected_output))
+        self.assertEqual(actual_output, expected_output)

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -6,7 +6,7 @@ from botocore.exceptions import ClientError
 
 from serverlessrepo import publish_application, update_application_metadata
 from serverlessrepo.exceptions import InvalidApplicationMetadataError, S3PermissionsRequired
-from serverlessrepo.parser import get_app_metadata, strip_app_metadata
+from serverlessrepo.parser import get_app_metadata, strip_app_metadata, yaml_dump
 from serverlessrepo.publish import (
     CREATE_APPLICATION,
     UPDATE_APPLICATION,
@@ -41,7 +41,7 @@ class TestPublishApplication(TestCase):
         }
         """
         self.template_dict = json.loads(self.template)
-        self.yaml_template_without_metadata = strip_app_metadata(self.template_dict)
+        self.yaml_template_without_metadata = yaml_dump(strip_app_metadata(self.template_dict))
         self.application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
         self.application_exists_error = ClientError(
             {

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -1,10 +1,12 @@
+import json
 from unittest import TestCase
 from mock import patch, Mock
+
 from botocore.exceptions import ClientError
 
 from serverlessrepo import publish_application, update_application_metadata
 from serverlessrepo.exceptions import InvalidApplicationMetadataError, S3PermissionsRequired
-from serverlessrepo.parser import parse_template, get_app_metadata, strip_app_metadata
+from serverlessrepo.parser import get_app_metadata, strip_app_metadata
 from serverlessrepo.publish import (
     CREATE_APPLICATION,
     UPDATE_APPLICATION,
@@ -23,22 +25,23 @@ class TestPublishApplication(TestCase):
         self.template = """
         {
             "Metadata": {
-                'AWS::ServerlessRepo::Application': {
-                    'Name': 'test-app',
-                    'Description': 'hello world',
-                    'Author': 'abc',
-                    'LicenseUrl': 's3://test-bucket/LICENSE',
-                    'ReadmeUrl': 's3://test-bucket/README.md',
-                    'Labels': ['test1', 'test2'],
-                    'HomePageUrl': 'https://github.com/abc/def',
-                    'SourceCodeUrl': 'https://github.com/abc/def',
-                    'SemanticVersion': '1.0.0'
+                "AWS::ServerlessRepo::Application": {
+                    "Name": "test-app",
+                    "Description": "hello world",
+                    "Author": "abc",
+                    "LicenseUrl": "s3://test-bucket/LICENSE",
+                    "ReadmeUrl": "s3://test-bucket/README.md",
+                    "Labels": ["test1", "test2"],
+                    "HomePageUrl": "https://github.com/abc/def",
+                    "SourceCodeUrl": "https://github.com/abc/def",
+                    "SemanticVersion": "1.0.0"
                 }
             },
-            "Resources": { 'Key1': {}, 'Key2': {} }
+            "Resources": { "Key1": {}, "Key2": {} }
         }
         """
-        self.yaml_template_without_metadata = strip_app_metadata(parse_template(self.template))
+        self.template_dict = json.loads(self.template)
+        self.yaml_template_without_metadata = strip_app_metadata(self.template_dict)
         self.application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
         self.application_exists_error = ClientError(
             {
@@ -68,7 +71,7 @@ class TestPublishApplication(TestCase):
             'create_application'
         )
 
-    def test_publish_empty_template(self):
+    def test_publish_raise_value_error_for_empty_template(self):
         with self.assertRaises(ValueError) as context:
             publish_application('')
 
@@ -77,13 +80,40 @@ class TestPublishApplication(TestCase):
         self.assertEqual(expected, message)
         self.serverlessrepo_mock.create_application.assert_not_called()
 
+    def test_publish_raise_value_error_for_not_dict_or_string_template(self):
+        with self.assertRaises(ValueError) as context:
+            publish_application(123)
+
+        message = str(context.exception)
+        expected = 'Input template should be a string or dictionary'
+        self.assertEqual(expected, message)
+        self.serverlessrepo_mock.create_application.assert_not_called()
+
+    @patch('serverlessrepo.publish.parse_template')
+    def test_publish_template_string_should_parse_template(self, parse_template_mock):
+        self.serverlessrepo_mock.create_application.return_value = {
+            'ApplicationId': self.application_id
+        }
+        parse_template_mock.return_value = self.template_dict
+        publish_application(self.template)
+        parse_template_mock.assert_called_with(self.template)
+
+    @patch('serverlessrepo.publish.copy.deepcopy')
+    def test_publish_template_dict_should_copy_template(self, copy_mock):
+        self.serverlessrepo_mock.create_application.return_value = {
+            'ApplicationId': self.application_id
+        }
+        copy_mock.return_value = self.template_dict
+        publish_application(self.template_dict)
+        copy_mock.assert_called_with(self.template_dict)
+
     def test_publish_new_application_should_create_application(self):
         self.serverlessrepo_mock.create_application.return_value = {
             'ApplicationId': self.application_id
         }
 
         actual_result = publish_application(self.template)
-        app_metadata_template = get_app_metadata(parse_template(self.template)).template_dict
+        app_metadata_template = get_app_metadata(self.template_dict).template_dict
         expected_result = {
             'application_id': self.application_id,
             'actions': [CREATE_APPLICATION],
@@ -97,8 +127,8 @@ class TestPublishApplication(TestCase):
         self.serverlessrepo_mock.update_application.assert_not_called()
         self.serverlessrepo_mock.create_application_version.assert_not_called()
 
-    def test_publish_exception_when_validate_create_application_request(self):
-        template_without_app_name = self.template.replace("'Name': 'test-app',", '')
+    def test_publish_raise_metadata_error_for_invalid_create_application_request(self):
+        template_without_app_name = self.template.replace('"Name": "test-app",', '')
         with self.assertRaises(InvalidApplicationMetadataError) as context:
             publish_application(template_without_app_name)
 
@@ -133,7 +163,7 @@ class TestPublishApplication(TestCase):
 
     def test_publish_existing_application_should_update_application_if_version_not_specified(self):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
-        template_without_version = self.template.replace("'SemanticVersion': '1.0.0'", '')
+        template_without_version = self.template.replace('"SemanticVersion": "1.0.0"', '')
 
         actual_result = publish_application(template_without_version)
         expected_result = {
@@ -286,18 +316,19 @@ class TestUpdateApplicationMetadata(TestCase):
         self.template = """
         {
             "Metadata": {
-                'AWS::ServerlessRepo::Application': {
-                    'Name': 'test-app',
-                    'Description': 'hello world',
-                    'Author': 'abc',
-                    'SemanticVersion': '1.0.0'
+                "AWS::ServerlessRepo::Application": {
+                    "Name": "test-app",
+                    "Description": "hello world",
+                    "Author": "abc",
+                    "SemanticVersion": "1.0.0"
                 }
             }
         }
         """
+        self.template_dict = json.loads(self.template)
         self.application_id = 'arn:aws:serverlessrepo:us-east-1:123456789012:applications/test-app'
 
-    def test_empty_template_throw_exception(self):
+    def test_raise_value_error_for_empty_template(self):
         with self.assertRaises(ValueError) as context:
             update_application_metadata('', self.application_id)
 
@@ -306,7 +337,7 @@ class TestUpdateApplicationMetadata(TestCase):
         self.assertEqual(expected, message)
         self.serverlessrepo_mock.update_application.assert_not_called()
 
-    def test_empty_application_id_throw_exception(self):
+    def test_raise_value_error_for_empty_application_id(self):
         with self.assertRaises(ValueError) as context:
             update_application_metadata(self.template, '')
 
@@ -314,6 +345,27 @@ class TestUpdateApplicationMetadata(TestCase):
         expected = 'Require SAM template and application ID to update application metadata'
         self.assertEqual(expected, message)
         self.serverlessrepo_mock.update_application.assert_not_called()
+
+    def test_raise_value_error_for_not_dict_or_string_template(self):
+        with self.assertRaises(ValueError) as context:
+            update_application_metadata(123, self.application_id)
+
+        message = str(context.exception)
+        expected = 'Input template should be a string or dictionary'
+        self.assertEqual(expected, message)
+        self.serverlessrepo_mock.update_application.assert_not_called()
+
+    @patch('serverlessrepo.publish.parse_template')
+    def test_update_application_metadata_with_template_string_should_parse_template(self, parse_template_mock):
+        parse_template_mock.return_value = self.template_dict
+        update_application_metadata(self.template, self.application_id)
+        parse_template_mock.assert_called_with(self.template)
+
+    @patch('serverlessrepo.publish.copy.deepcopy')
+    def test_publish_template_dict_should_copy_template(self, copy_mock):
+        copy_mock.return_value = self.template_dict
+        update_application_metadata(self.template_dict, self.application_id)
+        copy_mock.assert_called_with(self.template_dict)
 
     def test_update_application_metadata_ignore_irrelevant_fields(self):
         update_application_metadata(self.template, self.application_id)


### PR DESCRIPTION
*Description of changes:*
* Remove `AWS::ServerlessRepo::Application` metadata from the template so that sensitive information like s3 bucket name doesn't get exposed.
* Use `OrderedDict` in `json.loads`
* Accept parsed template as input to `publish_application` and `update_application_metadata`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
