### PR TITLE
chore: Add python 3.4 and 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
   - "3.6"
 
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs

--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     license=about['__license__'],
     keywords="AWS Serverless Application Repository",
     packages=find_packages(exclude=['tests', 'docs']),
-    # Support Python 2.7 and 3.6 or greater
+    # Support Python 2.7 and 3.4 or greater
     python_requires=(
-        '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*'
+        '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
     ),
     install_requires=REQUIRED,
     extras_require=EXTRAS,
@@ -61,6 +61,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Internet',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 whitelist_externals = make


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-serverlessrepo-python/issues/21

*Description of changes:*
Adding support for Python 3.4 and 3.5 since all the dependencies are compatible with these 2 versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
