### PR TITLE
chore: Wrap botocore ClientError into ServerlessRepoClientError

### DIFF
--- a/serverlessrepo/__version__.py
+++ b/serverlessrepo/__version__.py
@@ -1,7 +1,7 @@
 """Serverlessrepo version and package meta-data."""
 
 __title__ = 'serverlessrepo'
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 __license__ = 'Apache 2.0'
 __description__ = (
     'A Python library with convenience helpers for working '

--- a/serverlessrepo/exceptions.py
+++ b/serverlessrepo/exceptions.py
@@ -37,3 +37,9 @@ class S3PermissionsRequired(ServerlessRepoError):
               "permissions to the application artifacts you have uploaded to your S3 bucket. See " \
               "https://docs.aws.amazon.com/serverlessrepo/latest/devguide/serverless-app-publishing-applications.html" \
               " for more details."
+
+
+class ServerlessRepoClientError(ServerlessRepoError):
+    """Wrapper for botocore ClientError."""
+
+    MESSAGE = "{message}"

--- a/serverlessrepo/exceptions.py
+++ b/serverlessrepo/exceptions.py
@@ -42,9 +42,7 @@ class S3PermissionsRequired(ServerlessRepoError):
 class InvalidS3UriError(ServerlessRepoError):
     """Raised when the template contains invalid S3 URIs."""
 
-    MESSAGE = "Your SAM template contains invalid S3 URIs. Please make sure that you have uploaded application " \
-              "artifacts to S3 by packaging the template. See more details in " \
-              "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-package.html"  # noqa: E501 # pylint: disable=line-too-long
+    MESSAGE = "{message}"
 
 
 class ServerlessRepoClientError(ServerlessRepoError):

--- a/serverlessrepo/exceptions.py
+++ b/serverlessrepo/exceptions.py
@@ -39,6 +39,14 @@ class S3PermissionsRequired(ServerlessRepoError):
               " for more details."
 
 
+class InvalidS3UriError(ServerlessRepoError):
+    """Raised when the template contains invalid S3 URIs."""
+
+    MESSAGE = "Your SAM template contains invalid S3 URIs. Please make sure that you have uploaded application " \
+              "artifacts to S3 by packaging the template. See more details in " \
+              "https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-package.html"  # noqa: E501 # pylint: disable=line-too-long
+
+
 class ServerlessRepoClientError(ServerlessRepoError):
     """Wrapper for botocore ClientError."""
 

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -211,7 +211,7 @@ def _wrap_client_error(e):
 
     :param e: botocore exception
     :type e: ClientError
-    :return: S3PermissionsRequired or InvalidS3UriError or ServerlessRepoClientError
+    :return: S3PermissionsRequired or InvalidS3UriError or general ServerlessRepoClientError
     """
     error_code = e.response['Error']['Code']
     message = e.response['Error']['Message']
@@ -222,7 +222,7 @@ def _wrap_client_error(e):
             if match:
                 return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
         if "Invalid S3 URI" in message:
-            return InvalidS3UriError()
+            return InvalidS3UriError(message=message)
 
     return ServerlessRepoClientError(message=message)
 

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -11,7 +11,7 @@ from .parser import (
     yaml_dump, parse_template, get_app_metadata,
     parse_application_id, strip_app_metadata
 )
-from .exceptions import S3PermissionsRequired
+from .exceptions import ServerlessRepoClientError, S3PermissionsRequired
 
 CREATE_APPLICATION = 'CREATE_APPLICATION'
 UPDATE_APPLICATION = 'UPDATE_APPLICATION'
@@ -47,7 +47,7 @@ def publish_application(template, sar_client=None):
         actions = [CREATE_APPLICATION]
     except ClientError as e:
         if not _is_conflict_exception(e):
-            raise _wrap_s3_exception(e)
+            raise _wrap_client_error(e)
 
         # Update the application if it already exists
         error_message = e.response['Error']['Message']
@@ -57,7 +57,7 @@ def publish_application(template, sar_client=None):
             sar_client.update_application(**request)
             actions = [UPDATE_APPLICATION]
         except ClientError as e:
-            raise _wrap_s3_exception(e)
+            raise _wrap_client_error(e)
 
         # Create application version if semantic version is specified
         if app_metadata.semantic_version:
@@ -67,7 +67,7 @@ def publish_application(template, sar_client=None):
                 actions.append(CREATE_APPLICATION_VERSION)
             except ClientError as e:
                 if not _is_conflict_exception(e):
-                    raise _wrap_s3_exception(e)
+                    raise _wrap_client_error(e)
 
     return {
         'application_id': application_id,
@@ -195,9 +195,9 @@ def _create_application_version_request(app_metadata, application_id, template):
 
 def _is_conflict_exception(e):
     """
-    Check whether the boto3 ClientError is ConflictException.
+    Check whether the botocore ClientError is ConflictException.
 
-    :param e: boto3 exception
+    :param e: botocore exception
     :type e: ClientError
     :return: True if e is ConflictException
     """
@@ -205,13 +205,13 @@ def _is_conflict_exception(e):
     return error_code == 'ConflictException'
 
 
-def _wrap_s3_exception(e):
+def _wrap_client_error(e):
     """
-    Wrap S3 access denied exception with a better error message.
+    Wrap botocore ClientError exception into ServerlessRepoClientError.
 
-    :param e: boto3 exception
+    :param e: botocore exception
     :type e: ClientError
-    :return: S3PermissionsRequired if S3 access denied or the original exception
+    :return: S3PermissionsRequired or ServerlessRepoClientError
     """
     error_code = e.response['Error']['Code']
     message = e.response['Error']['Message']
@@ -221,7 +221,7 @@ def _wrap_s3_exception(e):
         if match:
             return S3PermissionsRequired(bucket=match.group(1), key=match.group(2))
 
-    return e
+    return ServerlessRepoClientError(message=message)
 
 
 def _get_publish_details(actions, app_metadata_template):

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -8,6 +8,7 @@ from serverlessrepo import publish_application, update_application_metadata
 from serverlessrepo.exceptions import (
     InvalidApplicationMetadataError,
     S3PermissionsRequired,
+    InvalidS3UriError,
     ServerlessRepoClientError
 )
 from serverlessrepo.parser import get_app_metadata, strip_app_metadata, yaml_dump
@@ -70,6 +71,15 @@ class TestPublishApplication(TestCase):
                 'Error': {
                     'Code': 'BadRequestException',
                     'Message': 'Failed to copy S3 object. Access denied: bucket=test-bucket, key=test-file'
+                }
+            },
+            'create_application'
+        )
+        self.invalid_s3_uri_exception = ClientError(
+            {
+                'Error': {
+                    'Code': 'BadRequestException',
+                    'Message': 'Invalid S3 URI'
                 }
             },
             'create_application'
@@ -141,7 +151,7 @@ class TestPublishApplication(TestCase):
         # create_application shouldn't be called if application metadata is invalid
         self.serverlessrepo_mock.create_application.assert_not_called()
 
-    def test_publish_raise_serverlessrepo_error_when_create_application(self):
+    def test_publish_raise_serverlessrepo_client_error_when_create_application(self):
         self.serverlessrepo_mock.create_application.side_effect = self.not_conflict_exception
 
         # should raise exception if it's not ConflictException
@@ -152,7 +162,7 @@ class TestPublishApplication(TestCase):
         self.serverlessrepo_mock.update_application.assert_not_called()
         self.serverlessrepo_mock.create_application_version.assert_not_called()
 
-    def test_publish_raise_s3_error_when_create_application(self):
+    def test_publish_raise_s3_permission_error_when_create_application(self):
         self.serverlessrepo_mock.create_application.side_effect = self.s3_denied_exception
         with self.assertRaises(S3PermissionsRequired) as context:
             publish_application(self.template)
@@ -161,9 +171,13 @@ class TestPublishApplication(TestCase):
         self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
                       "'test-bucket', key 'test-file'.", message)
 
-        # shouldn't call the following APIs if the exception isn't application already exists
-        self.serverlessrepo_mock.update_application.assert_not_called()
-        self.serverlessrepo_mock.create_application_version.assert_not_called()
+    def test_publish_raise_invalid_s3_uri_when_create_application(self):
+        self.serverlessrepo_mock.create_application.side_effect = self.invalid_s3_uri_exception
+        with self.assertRaises(InvalidS3UriError) as context:
+            publish_application(self.template)
+
+        message = str(context.exception)
+        self.assertIn("Your SAM template contains invalid S3 URIs.", message)
 
     def test_publish_existing_application_should_update_application_if_version_not_specified(self):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
@@ -191,15 +205,13 @@ class TestPublishApplication(TestCase):
         # create_application_version shouldn't be called if version is not provided
         self.serverlessrepo_mock.create_application_version.assert_not_called()
 
-    def test_publish_raise_s3_error_when_update_application(self):
+    @patch('serverlessrepo.publish._wrap_client_error')
+    def test_publish_wrap_client_error_when_update_application(self, wrap_client_error_mock):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
-        self.serverlessrepo_mock.update_application.side_effect = self.s3_denied_exception
-        with self.assertRaises(S3PermissionsRequired) as context:
+        self.serverlessrepo_mock.update_application.side_effect = self.not_conflict_exception
+        wrap_client_error_mock.return_value = ServerlessRepoClientError(message="client error")
+        with self.assertRaises(ServerlessRepoClientError):
             publish_application(self.template)
-
-        message = str(context.exception)
-        self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
-                      "'test-bucket', key 'test-file'.", message)
 
         # create_application_version shouldn't be called if update_application fails
         self.serverlessrepo_mock.create_application_version.assert_not_called()
@@ -261,23 +273,13 @@ class TestPublishApplication(TestCase):
         }
         self.serverlessrepo_mock.create_application_version.assert_called_once_with(**expected_request)
 
-    def test_publish_raise_serverlessrepo_error_when_create_application_version(self):
+    @patch('serverlessrepo.publish._wrap_client_error')
+    def test_publish_wrap_client_error_when_create_application_version(self, wrap_client_error_mock):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
         self.serverlessrepo_mock.create_application_version.side_effect = self.not_conflict_exception
-
-        # should raise exception if it's not ConflictException
+        wrap_client_error_mock.return_value = ServerlessRepoClientError(message="client error")
         with self.assertRaises(ServerlessRepoClientError):
             publish_application(self.template)
-
-    def test_publish_raise_s3_error_when_create_application_version(self):
-        self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
-        self.serverlessrepo_mock.create_application_version.side_effect = self.s3_denied_exception
-        with self.assertRaises(S3PermissionsRequired) as context:
-            publish_application(self.template)
-
-        message = str(context.exception)
-        self.assertIn("The AWS Serverless Application Repository does not have read access to bucket "
-                      "'test-bucket', key 'test-file'.", message)
 
     def test_create_application_with_passed_in_sar_client(self):
         sar_client = Mock()

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -177,7 +177,7 @@ class TestPublishApplication(TestCase):
             publish_application(self.template)
 
         message = str(context.exception)
-        self.assertIn("Your SAM template contains invalid S3 URIs.", message)
+        self.assertIn("Invalid S3 URI", message)
 
     def test_publish_existing_application_should_update_application_if_version_not_specified(self):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error


### PR DESCRIPTION
*Description of changes:*
Wrap the botocore ClientError so that consumers can easily catch exceptions thrown inside this library, and the ugly botocore stack trace won't be printed in sam cli.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
