### PR TITLE
Support LicenseBody and ReadmeBody application metadata properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ share_application_with_accounts(application_id, ['123456789013', '123456789014']
   * Pipenv will automatically update [Pipfile](./Pipfile) and [Pipfile.lock](./Pipfile.lock) for you.
   * Add new dependencies to [setup.py](./setup.py) install_requires if they are needed for consumers of this library.
 * Verify that everything works: `make build`
-  * You can run `make tests` separately to verify that tests pass.
+  * You can run `make test` separately to verify that tests pass.
   * Check code style with `make flake` and `make lint`.
 * Make code changes, run all verifications again before sending a Pull Request: `make pr`
 

--- a/serverlessrepo/application_metadata.py
+++ b/serverlessrepo/application_metadata.py
@@ -11,7 +11,9 @@ class ApplicationMetadata(object):
     DESCRIPTION = 'Description'
     AUTHOR = 'Author'
     SPDX_LICENSE_ID = 'SpdxLicenseId'
+    LICENSE_BODY = 'LicenseBody'
     LICENSE_URL = 'LicenseUrl'
+    README_BODY = 'ReadmeBody'
     README_URL = 'ReadmeUrl'
     LABELS = 'Labels'
     HOME_PAGE_URL = 'HomePageUrl'
@@ -30,7 +32,9 @@ class ApplicationMetadata(object):
         self.description = app_metadata.get(self.DESCRIPTION)
         self.author = app_metadata.get(self.AUTHOR)
         self.spdx_license_id = app_metadata.get(self.SPDX_LICENSE_ID)
+        self.license_body = app_metadata.get(self.LICENSE_BODY)
         self.license_url = app_metadata.get(self.LICENSE_URL)
+        self.readme_body = app_metadata.get(self.README_BODY)
         self.readme_url = app_metadata.get(self.README_URL)
         self.labels = app_metadata.get(self.LABELS)
         self.home_page_url = app_metadata.get(self.HOME_PAGE_URL)
@@ -52,6 +56,13 @@ class ApplicationMetadata(object):
         """
         missing_props = [p for p in required_props if not getattr(self, p)]
         if missing_props:
-            missing_props_str = ', '.join(sorted(missing_props))
-            raise InvalidApplicationMetadataError(properties=missing_props_str)
+            raise InvalidApplicationMetadataError(
+                error_message='{} properties not provided'.format(', '.join(sorted(missing_props))))
+
+        if self.license_body and self.license_url:
+            raise InvalidApplicationMetadataError(error_message='provide either LicenseBody or LicenseUrl')
+
+        if self.readme_body and self.readme_url:
+            raise InvalidApplicationMetadataError(error_message='provide either ReadmeBody or ReadmeUrl')
+
         return True

--- a/serverlessrepo/exceptions.py
+++ b/serverlessrepo/exceptions.py
@@ -14,7 +14,7 @@ class ServerlessRepoError(Exception):
 class InvalidApplicationMetadataError(ServerlessRepoError):
     """Raised when invalid application metadata is provided."""
 
-    MESSAGE = "Required application metadata properties not provided: '{properties}'"
+    MESSAGE = "Invalid application metadata: '{error_message}'"
 
 
 class ApplicationMetadataNotFoundError(ServerlessRepoError):

--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -136,8 +136,10 @@ def _create_application_request(app_metadata, template):
         'Description': app_metadata.description,
         'HomePageUrl': app_metadata.home_page_url,
         'Labels': app_metadata.labels,
+        'LicenseBody': app_metadata.license_body,
         'LicenseUrl': app_metadata.license_url,
         'Name': app_metadata.name,
+        'ReadmeBody': app_metadata.readme_body,
         'ReadmeUrl': app_metadata.readme_url,
         'SemanticVersion': app_metadata.semantic_version,
         'SourceCodeUrl': app_metadata.source_code_url,
@@ -165,6 +167,7 @@ def _update_application_request(app_metadata, application_id):
         'Description': app_metadata.description,
         'HomePageUrl': app_metadata.home_page_url,
         'Labels': app_metadata.labels,
+        'ReadmeBody': app_metadata.readme_body,
         'ReadmeUrl': app_metadata.readme_url
     }
     return {k: v for k, v in request.items() if v}

--- a/tests/unit/test_application_metadata.py
+++ b/tests/unit/test_application_metadata.py
@@ -12,7 +12,9 @@ class TestApplicationMetadata(TestCase):
             'Description': 'description',
             'Author': 'author',
             'SpdxLicenseId': '123456',
+            'LicenseBody': 'license body',
             'LicenseUrl': 's3://bucket/license.txt',
+            'ReadmeBody': 'readme body',
             'ReadmeUrl': 's3://bucket/README.md',
             'Labels': ['label1', 'label2', 'label3'],
             'HomePageUrl': 'https://github.com/my-id/my-repo/',
@@ -24,14 +26,16 @@ class TestApplicationMetadata(TestCase):
         self.assertEqual(app_metadata.description, app_metadata_dict['Description'])
         self.assertEqual(app_metadata.author, app_metadata_dict['Author'])
         self.assertEqual(app_metadata.spdx_license_id, app_metadata_dict['SpdxLicenseId'])
+        self.assertEqual(app_metadata.license_body, app_metadata_dict['LicenseBody'])
         self.assertEqual(app_metadata.license_url, app_metadata_dict['LicenseUrl'])
+        self.assertEqual(app_metadata.readme_body, app_metadata_dict['ReadmeBody'])
         self.assertEqual(app_metadata.readme_url, app_metadata_dict['ReadmeUrl'])
         self.assertEqual(app_metadata.labels, app_metadata_dict['Labels'])
         self.assertEqual(app_metadata.home_page_url, app_metadata_dict['HomePageUrl'])
         self.assertEqual(app_metadata.semantic_version, app_metadata_dict['SemanticVersion'])
         self.assertEqual(app_metadata.source_code_url, app_metadata_dict['SourceCodeUrl'])
 
-    def test_invalid_app_metadata(self):
+    def test_required_properties_not_provided(self):
         app_metadata_dict = {'description': 'hello'}
         app_metadata = ApplicationMetadata(app_metadata_dict)
         required_props = ['author', 'name']
@@ -39,7 +43,32 @@ class TestApplicationMetadata(TestCase):
             app_metadata.validate(required_props)
 
         message = str(context.exception)
-        self.assertTrue(', '.join(required_props) in message)
+        expected = 'author, name properties not provided'
+        self.assertTrue(expected in message)
+
+    def test_both_license_parameters_provided(self):
+        app_metadata_dict = {
+            'LicenseBody': 'license body',
+            'LicenseUrl': 's3://bucket/license.txt',
+        }
+        app_metadata = ApplicationMetadata(app_metadata_dict)
+        with self.assertRaises(InvalidApplicationMetadataError) as context:
+            app_metadata.validate([])
+
+        message = str(context.exception)
+        self.assertTrue('provide either LicenseBody or LicenseUrl' in message)
+
+    def test_both_readme_parameters_provided(self):
+        app_metadata_dict = {
+            'ReadmeBody': 'Readme body',
+            'ReadmeUrl': 's3://bucket/README.md',
+        }
+        app_metadata = ApplicationMetadata(app_metadata_dict)
+        with self.assertRaises(InvalidApplicationMetadataError) as context:
+            app_metadata.validate([])
+
+        message = str(context.exception)
+        self.assertTrue('provide either ReadmeBody or ReadmeUrl' in message)
 
     def test_valid_app_metadata(self):
         app_metadata = ApplicationMetadata({})

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -147,7 +147,7 @@ class TestPublishApplication(TestCase):
             publish_application(template_without_app_name)
 
         message = str(context.exception)
-        self.assertEqual("Required application metadata properties not provided: 'name'", message)
+        self.assertEqual("Invalid application metadata: 'name properties not provided'", message)
         # create_application shouldn't be called if application metadata is invalid
         self.serverlessrepo_mock.create_application.assert_not_called()
 


### PR DESCRIPTION
*Description of changes:*
Added the possibility to use the application metadata properties 'LicenseBody' and 'ReadmeBody' instead their 'Url' counter parts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
