### PR TITLE
fix: Add ReadmeBody and LicenseBody in output details of publishing app

### DIFF
--- a/serverlessrepo/publish.py
+++ b/serverlessrepo/publish.py
@@ -249,7 +249,8 @@ def _get_publish_details(actions, app_metadata_template):
         ApplicationMetadata.DESCRIPTION,
         ApplicationMetadata.HOME_PAGE_URL,
         ApplicationMetadata.LABELS,
-        ApplicationMetadata.README_URL
+        ApplicationMetadata.README_URL,
+        ApplicationMetadata.README_BODY
     ]
 
     if CREATE_APPLICATION_VERSION in actions:

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -335,7 +335,7 @@ class TestPublishApplication(TestCase):
         }
         self.assertEqual(expected_result, actual_result)
 
-     def test_update_application_with_readmebody(self):
+    def test_update_application_with_readmebody(self):
         self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
         template_with_readmebody = self.template \
             .replace('"SemanticVersion": "1.0.0"', '') \

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -311,6 +311,49 @@ class TestPublishApplication(TestCase):
         self.serverlessrepo_mock.update_application.assert_not_called()
         self.serverlessrepo_mock.create_application_version.assert_not_called()
 
+    def test_create_application_with_licensebody(self):
+        self.serverlessrepo_mock.create_application.return_value = {
+            'ApplicationId': self.application_id
+        }
+        template_with_licensebody = self.template \
+            .replace('"LicenseUrl": "s3://test-bucket/LICENSE"', '"LicenseBody": "test test"')
+        actual_result = publish_application(template_with_licensebody)
+        expected_result = {
+            'application_id': self.application_id,
+            'actions': [CREATE_APPLICATION],
+            'details': {
+                'Author': 'abc',
+                'Description': 'hello world',
+                'HomePageUrl': 'https://github.com/abc/def',
+                'Labels': ['test1', 'test2'],
+                'LicenseBody': 'test test',
+                'Name': 'test-app',
+                'ReadmeUrl': 's3://test-bucket/README.md',
+                'SemanticVersion': '1.0.0',
+                'SourceCodeUrl': 'https://github.com/abc/def'
+            }
+        }
+        self.assertEqual(expected_result, actual_result)
+
+     def test_update_application_with_readmebody(self):
+        self.serverlessrepo_mock.create_application.side_effect = self.application_exists_error
+        template_with_readmebody = self.template \
+            .replace('"SemanticVersion": "1.0.0"', '') \
+            .replace('"ReadmeUrl": "s3://test-bucket/README.md"', '"ReadmeBody": "test test"')
+        actual_result = publish_application(template_with_readmebody)
+        expected_result = {
+            'application_id': self.application_id,
+            'actions': [UPDATE_APPLICATION],
+            'details': {
+                'Description': 'hello world',
+                'Author': 'abc',
+                'ReadmeBody': 'test test',
+                'Labels': ['test1', 'test2'],
+                'HomePageUrl': 'https://github.com/abc/def'
+            }
+        }
+        self.assertEqual(expected_result, actual_result)
+
 
 class TestUpdateApplicationMetadata(TestCase):
     def setUp(self):


### PR DESCRIPTION
*Description of changes:*
Follow up of https://github.com/awslabs/aws-serverlessrepo-python/pull/28. During test, found the ReadmeBody is not added to the output details when updating application.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
